### PR TITLE
Fix copy method does not work

### DIFF
--- a/lib/kura/client.rb
+++ b/lib/kura/client.rb
@@ -486,7 +486,7 @@ module Kura
              &blk)
       write_disposition = mode_to_write_disposition(mode)
       configuration = Google::Apis::BigqueryV2::JobConfiguration.new({
-        copy: Google::Apis::BigqueryV2::JobConfigurationCopy.new({
+        copy: Google::Apis::BigqueryV2::JobConfigurationTableCopy.new({
           destination_table: Google::Apis::BigqueryV2::TableReference.new({
             project_id: dest_project_id,
             dataset_id: dest_dataset_id,


### PR DESCRIPTION
I got `uninitialized constant Google::Apis::BigqueryV2::JobConfigurationCopy` when I call `copy` method.
because `JobConfigurationCopy` does not exist, I think it should be `JobConfigurationTableCopy`.

http://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/BigqueryV2/JobConfigurationTableCopy
