### PR TITLE
Add support for query to external data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ client = Kura.client(JSON.parse(File.read(json_file_path)))
 
 # b. With GCE bigquery scope (Only available on Google Compute Engine instance)
 client = Kura.client
+
+# c. With External Data Sources. For example, accessing data hosted within Google Drive requires an additional OAuth scope.
+client = Kura.client(.., scope: "https://www.googleapis.com/auth/drive")
 ```
 
 ### Job API
@@ -49,6 +52,7 @@ client.copy("src_dataset", "src_table", "dest_dataset", "dest_table", wait: 120)
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/nagachika/kura.
 
+> Memo: If run to google sheets testing requires environment variable `ENV['GOOGLE_SHEETS_FILE_URL']`.
 
 ## License
 

--- a/lib/kura.rb
+++ b/lib/kura.rb
@@ -43,7 +43,7 @@ module Kura
   #     Kura.client(gcp_project_id, email_address, prm_file_contents)
   #     Kura.client(gcp_project_id, email_address, private_key_object)
   #
-  def self.client(project_id=nil, email_address=nil, private_key=nil, http_options: {timeout: 60})
+  def self.client(project_id=nil, email_address=nil, private_key=nil, scope: nil, http_options: {timeout: 60})
     if email_address.nil? and private_key.nil?
       if project_id.is_a?(String)
         credential = JSON.parse(File.binread(project_id))
@@ -58,6 +58,6 @@ module Kura
     elsif private_key
       private_key = get_private_key(private_key)
     end
-    self::Client.new(default_project_id: project_id, email_address: email_address, private_key: private_key, http_options: http_options)
+    self::Client.new(default_project_id: project_id, email_address: email_address, private_key: private_key, scope: scope, http_options: http_options)
   end
 end

--- a/lib/kura/client.rb
+++ b/lib/kura/client.rb
@@ -8,9 +8,9 @@ require "kura/extensions"
 
 module Kura
   class Client
-    def initialize(default_project_id: nil, email_address: nil, private_key: nil, http_options: {timeout: 60}, default_retries: 5)
+    def initialize(default_project_id: nil, email_address: nil, private_key: nil, scope: nil, http_options: {timeout: 60}, default_retries: 5)
       @default_project_id = default_project_id
-      @scope = "https://www.googleapis.com/auth/bigquery"
+      @scope = ["https://www.googleapis.com/auth/bigquery"] | (scope ? scope.is_a?(Array) ? scope : [scope] : [])
       @email_address = email_address
       @private_key = private_key
       if @email_address and @private_key
@@ -24,7 +24,7 @@ module Kura
         Faraday.default_connection.options.timeout = 60
         auth.fetch_access_token!
       else
-        auth = Google::Auth.get_application_default([@scope])
+        auth = Google::Auth.get_application_default(@scope)
         auth.fetch_access_token!
       end
       Google::Apis::RequestOptions.default.retries = default_retries

--- a/lib/kura/client.rb
+++ b/lib/kura/client.rb
@@ -378,6 +378,7 @@ module Kura
               use_legacy_sql: true,
               maximum_billing_tier: nil,
               maximum_bytes_billed: nil,
+              external_data_configuration: nil,
               project_id: @default_project_id,
               job_project_id: @default_project_id,
               job_id: nil,
@@ -419,6 +420,9 @@ module Kura
             Google::Apis::BigqueryV2::UserDefinedFunctionResource.new({ inline_code: r })
           end
         end
+      end
+      if external_data_configuration
+        configuration.query.table_definitions = external_data_configuration
       end
       insert_job(configuration, wait: wait, job_id: job_id, project_id: job_project_id, &blk)
     end


### PR DESCRIPTION
refs: [external-data-sources document](https://cloud.google.com/bigquery/external-data-sources)

* Add keyword argument `scope` to `client` for other than bigquery
* Add keyword argument `external_data_configuration` to `query`  [configuration.query.tableDefinitions](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query.tableDefinitions)
