### PR TITLE
cancel_job error message changed

### DIFF
--- a/test/kura_integration_test.rb
+++ b/test/kura_integration_test.rb
@@ -612,7 +612,7 @@ class KuraIntegrationTest < Test::Unit::TestCase
     end
     err = assert_raise(Kura::ApiError) { @client.wait_job(jobid) }
     power_assert do
-      err.reason == "stopped" and err.message =~ /Job cancel was requested./
+      err.reason == "stopped" and err.message =~ /Job execution was cancelled/
     end
   end
 


### PR DESCRIPTION
run test `test_cancel_job`

```
Failure:
        err.reason == "stopped" and err.message =~ /Job cancel was requested./
        |          |                |   |       |
        |          |                |   |       nil
        |          |                |   "reason=stopped message=Job execution was cancelled: User requested cancellation"
        |          |                #<Kura::ApiError: reason=stopped message=Job execution was cancelled: User requested cancellation>
        |          true
        #<Kura::ApiError: reason=stopped message=Job execution was cancelled: User requested cancellation>
test_cancel_job(KuraIntegrationTest)
/Users/nakamura/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/test-unit-power_assert-0.1.2/lib/test/unit/power_assert.rb:28:in `block in assert'
/Users/nakamura/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/test-unit-power_assert-0.1.2/lib/test/unit/power_assert.rb:23:in `assert'
/Users/nakamura/work/kura/test/kura_integration_test.rb:614:in `test_cancel_job'
     611:       job.status.state == "DONE" or job.status.state == "PENDING"
     612:     end
     613:     err = assert_raise(Kura::ApiError) { @client.wait_job(jobid) }
  => 614:     power_assert do
     615:       err.reason == "stopped" and err.message =~ /Job cancel was requested./
     616:     end
     617:   end
```

message changed? `Job execution was cancelled: User requested cancellation`

