### PR TITLE
Support BigQuery Model APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
-  - 2.2.2
-before_install: gem install bundler -v 1.10.5
+  - 2.5.5
+  - 2.6.3
+before_install: gem install bundler -v 1.17.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+# 0.3.0
+
+## Enhancements
+
+* Support [Models API](https://cloud.google.com/bigquery/docs/reference/rest/v2/models) to manipulate BigQuery ML models.
+
 # 0.2.33
 
 ## Fixes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,10 @@
 
 * Support [Models API](https://cloud.google.com/bigquery/docs/reference/rest/v2/models) to manipulate BigQuery ML models.
 
+## Changes
+
+* Update version dependency of google-api-client.gem to support BigQuery Models API.
+
 # 0.2.33
 
 ## Fixes

--- a/kura.gemspec
+++ b/kura.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_runtime_dependency "google-api-client", ">= 0.9.11"
+  spec.add_runtime_dependency "google-api-client", [">= 0.28.6", "!= 0.29.1"]
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/kura.gemspec
+++ b/kura.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "google-api-client", ">= 0.9.11"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "test-unit-power_assert"

--- a/lib/kura/version.rb
+++ b/lib/kura/version.rb
@@ -1,3 +1,3 @@
 module Kura
-  VERSION = "0.2.34"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Add support for Models resource in BigQuery API v2 (https://cloud.google.com/bigquery/docs/reference/rest/v2/models).

To support models resources, I updated dependency for google-api-client to `>= 0.28.6`, and eliminated `0.29.1` because it isn't contains models resources by accident. See https://github.com/googleapis/google-api-ruby-client/issues/790