### PR TITLE
get rid of not found error for job in some locations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 2.5.5
-  - 2.6.3
+  - 2.5.7
+  - 2.6.5
 before_install: gem install bundler -v 1.17.1

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 * Handle table whose schema without 'mode' field. The tables created by New BigQuery Web Console could have such malformed schema.
   Thanks for GCPUG Slack for notice this issue.
 * Add location: parameter for `job`/`cancel_job`/`wait_job` methods.
+* `insert_dataset` can now create dataset with attributes like `location`.
 
 # 0.3.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,10 @@
-# 0.3.1
+# 0.4.0
 
 ## Enhancements
 
 * Handle table whose schema without 'mode' field. The tables created by New BigQuery Web Console could have such malformed schema.
   Thanks for GCPUG Slack for notice this issue.
+* Add location: parameter for `job`/`cancel_job`/`wait_job` methods.
 
 # 0.3.0
 

--- a/lib/kura/client.rb
+++ b/lib/kura/client.rb
@@ -131,7 +131,15 @@ module Kura
     end
 
     def insert_dataset(dataset_id, project_id: @default_project_id, &blk)
-      obj = Google::Apis::BigqueryV2::Dataset.new(dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(project_id: project_id, dataset_id: dataset_id))
+      case dataset_id
+      when String
+        obj = Google::Apis::BigqueryV2::Dataset.new(dataset_reference: Google::Apis::BigqueryV2::DatasetReference.new(project_id: project_id, dataset_id: dataset_id))
+      when Hash
+        obj = Google::Apis::BigqueryV2::Dataset.new(**dataset_id)
+      when Google::Apis::BigqueryV2::Dataset
+        obj = dataset_id
+      end
+
       @api.insert_dataset(project_id, obj, &blk)
     rescue
       process_error($!)

--- a/lib/kura/client.rb
+++ b/lib/kura/client.rb
@@ -588,20 +588,20 @@ module Kura
       insert_job(configuration, wait: wait, job_id: job_id, project_id: job_project_id, &blk)
     end
 
-    def job(job_id, project_id: @default_project_id, &blk)
+    def job(job_id, location: nil, project_id: @default_project_id, &blk)
       if blk
-        @api.get_job(project_id, job_id) do |j, e|
+        @api.get_job(project_id, job_id, location: location) do |j, e|
           j.kura_api = self if j
           blk.call(j, e)
         end
       else
-        @api.get_job(project_id, job_id).tap{|j| j.kura_api = self if j }
+        @api.get_job(project_id, job_id, location: location).tap{|j| j.kura_api = self if j }
       end
     rescue
       process_error($!)
     end
 
-    def cancel_job(job, project_id: @default_project_id, &blk)
+    def cancel_job(job, location: nil, project_id: @default_project_id, &blk)
       case job
       when String
         jobid = job
@@ -612,13 +612,13 @@ module Kura
         raise TypeError, "Kura::Client#cancel_job accept String(job-id) or Google::Apis::BigqueryV2::Job"
       end
       if blk
-        @api.cancel_job(project_id, jobid) do |r, e|
+        @api.cancel_job(project_id, jobid, location: location) do |r, e|
           j = (r && r.job)
           j.kura_api = self if j
           blk.call(j, e)
         end
       else
-        @api.cancel_job(project_id, jobid).job.tap{|j| j.kura_api = self if j }
+        @api.cancel_job(project_id, jobid, location: location).job.tap{|j| j.kura_api = self if j }
       end
     end
 
@@ -638,19 +638,20 @@ module Kura
       return false
     end
 
-    def wait_job(job, timeout=60*10, project_id: @default_project_id)
+    def wait_job(job, timeout=60*10, location: nil, project_id: @default_project_id)
       case job
       when String
         job_id = job
       when Google::Apis::BigqueryV2::Job
         project_id = job.job_reference.project_id
         job_id = job.job_reference.job_id
+        location = job.job_reference.location
       else
         raise TypeError, "Kura::Client#wait_job accept String(job-id) or Google::Apis::BigqueryV2::Job"
       end
       expire = Time.now + timeout
       while expire > Time.now
-        j = job(job_id, project_id: project_id)
+        j = job(job_id, project_id: project_id, location: location)
         if job_finished?(j)
           return j
         end

--- a/lib/kura/version.rb
+++ b/lib/kura/version.rb
@@ -1,3 +1,3 @@
 module Kura
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/test/kura_integration_test.rb
+++ b/test/kura_integration_test.rb
@@ -72,6 +72,21 @@ class KuraIntegrationTest < Test::Unit::TestCase
     @client.delete_dataset(@name) rescue nil
   end
 
+  def test_insert_dataset_with_location
+    @name = "Kura_test"
+
+    dataset = @client.dataset(@name)
+    assert_nil(dataset)
+
+    @client.insert_dataset({ dataset_reference: { dataset_id: @name }, location: "asia-northeast1" })
+    dataset = @client.dataset(@name)
+    assert_equal(@project_id, dataset.dataset_reference.project_id)
+    assert_equal(@name, dataset.dataset_reference.dataset_id)
+    assert_equal("asia-northeast1", dataset.location)
+  ensure
+    @client.delete_dataset(@name) rescue nil
+  end
+
   def test_tables
     @client.tables("samples", project_id: "publicdata").tap do |result|
       assert_equal(7, result.size)


### PR DESCRIPTION
Now BigQuery API `jobs.get` requires `location` as a part of jobReference for jobs in non-US/EU regions.
`Kura::Client#job`, `#wait_job`, `#cancel_job` now accept `location:` keyword arguments to specify job's location.

And `Kura::Client#insert_dataset` should be able to create dataset with some attributes like location/description/default_table_expiration_ms etc...
Now `#insert_dataset` accept Hash or `Google::Apis::BigqueryV2::Dataset` instance in addition to dataset_id(String).