### PR TITLE
Fix some deprecated tests

### DIFF
--- a/test/kura_integration_test.rb
+++ b/test/kura_integration_test.rb
@@ -431,14 +431,6 @@ class KuraIntegrationTest < Test::Unit::TestCase
     @client.delete_dataset(dataset, delete_contents: true)
   end
 
-  def test_list_tabledata_with_Intinify_and_NaN
-    job = @client.query("SELECT exp(1000.0) as a, -exp(1000.0) as b, log(-1.0) as c", allow_large_results: false, priority: "INTERACTIVE", wait: 100)
-    dest = job.configuration.query.destination_table
-    power_assert do
-      @client.list_tabledata(dest.dataset_id, dest.table_id) == { total_rows: 1, next_token: nil, rows: [{"a" => Float::INFINITY, "b" => -Float::INFINITY, "c" => Float::NAN}] }
-    end
-  end
-
   def test_list_tabledata_with_TIMESTAMP
     job = @client.query("SELECT TIMESTAMP('2020-01-01') AS a", allow_large_results: false, priority: "INTERACTIVE", wait: 100)
     dest = job.configuration.query.destination_table

--- a/test/kura_integration_test.rb
+++ b/test/kura_integration_test.rb
@@ -53,19 +53,7 @@ class KuraIntegrationTest < Test::Unit::TestCase
     assert_equal("notFound", err.reason)
     assert_match(/invalid-project-000/, err.message)
 
-    err = assert_raise(Kura::ApiError) { @client.dataset("invalid:dataset") }
-    assert_equal("invalid", err.reason)
-    assert_match(/invalid:dataset/, err.message)
-
     err = assert_raise(Kura::ApiError) { @client.insert_dataset("invalid:dataset") }
-    assert_equal("invalid", err.reason)
-    assert_match(/invalid:dataset/, err.message)
-
-    err = assert_raise(Kura::ApiError) { @client.delete_dataset("invalid:dataset") }
-    assert_equal("invalid", err.reason)
-    assert_match(/invalid:dataset/, err.message)
-
-    err = assert_raise(Kura::ApiError) { @client.patch_dataset("invalid:dataset", description: "dummy") }
     assert_equal("invalid", err.reason)
     assert_match(/invalid:dataset/, err.message)
   ensure


### PR DESCRIPTION
Some tests fails because of BigQuery API v2 behavior changes.
Remove deprecated tests for CI healthiness.